### PR TITLE
refactor: remove goerli and add polygon amoy

### DIFF
--- a/ape_blockscout/utils.py
+++ b/ape_blockscout/utils.py
@@ -9,9 +9,9 @@ API_KEY_ENV_KEY_MAP = {
 }
 
 NETWORKS: Dict[str, List[str]] = {
-    "base": ["mainnet", "goerli", "sepolia"],
-    "ethereum": ["mainnet", "goerli", "sepolia"],
+    "base": ["mainnet", "sepolia"],
+    "ethereum": ["mainnet", "sepolia"],
     "gnosis": ["mainnet", "chiado"],
-    "optimism": ["mainnet", "goerli", "sepolia"],
+    "optimism": ["mainnet", "sepolia"],
     "polygon": ["mainnet"],
 }

--- a/ape_blockscout/utils.py
+++ b/ape_blockscout/utils.py
@@ -13,5 +13,5 @@ NETWORKS: Dict[str, List[str]] = {
     "ethereum": ["mainnet", "sepolia"],
     "gnosis": ["mainnet", "chiado"],
     "optimism": ["mainnet", "sepolia"],
-    "polygon": ["mainnet"],
+    "polygon": ["mainnet", "amoy"],
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -228,12 +228,10 @@ class MockBlockscoutBackend:
         return {
             "base": {
                 "mainnet": "https://base.blockscout.com/api",
-                "goerli": "https://base-goerli.blockscout.com/api",
                 "sepolia": "https://base-sepolia.blockscout.com/api",
             },
             "ethereum": {
                 "mainnet": "https://eth.blockscout.com/api",
-                "goerli": "https://eth-goerli.blockscout.com/api",
                 "sepolia": "https://eth-sepolia.blockscout.com/api",
             },
             "gnosis": {
@@ -242,7 +240,6 @@ class MockBlockscoutBackend:
             },
             "optimism": {
                 "mainnet": "https://optimism.blockscout.com/api",
-                "goerli": "https://optimism-goerli.blockscout.com/api",
                 "sepolia": "https://optimism-sepolia.blockscout.com/api",
             },
             "polygon": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,6 +244,7 @@ class MockBlockscoutBackend:
             },
             "polygon": {
                 "mainnet": "https://polygon.blockscout.com/api",
+                "amoy": "https://polygon-amoy.blockscout.com/api",
             },
         }
 

--- a/tests/test_blockscout.py
+++ b/tests/test_blockscout.py
@@ -30,8 +30,6 @@ base_url_test = pytest.mark.parametrize(
         # Ethereum
         ("ethereum", "mainnet", "eth.blockscout.com"),
         ("ethereum", "mainnet-fork", "eth.blockscout.com"),
-        ("ethereum", "goerli", "eth-goerli.blockscout.com"),
-        ("ethereum", "goerli-fork", "eth-goerli.blockscout.com"),
         ("ethereum", "sepolia", "eth-sepolia.blockscout.com"),
         ("ethereum", "sepolia-fork", "eth-sepolia.blockscout.com"),
         # Gnosis
@@ -42,8 +40,6 @@ base_url_test = pytest.mark.parametrize(
         # Optimism
         ("optimism", "mainnet", "optimism.blockscout.com"),
         ("optimism", "mainnet-fork", "optimism.blockscout.com"),
-        ("optimism", "goerli", "optimism-goerli.blockscout.com"),
-        ("optimism", "goerli-fork", "optimism-goerli.blockscout.com"),
         ("optimism", "sepolia", "optimism-sepolia.blockscout.com"),
         ("optimism", "sepolia-fork", "optimism-sepolia.blockscout.com"),
         # Polygon

--- a/tests/test_blockscout.py
+++ b/tests/test_blockscout.py
@@ -45,6 +45,8 @@ base_url_test = pytest.mark.parametrize(
         # Polygon
         ("polygon", "mainnet", "polygon.blockscout.com"),
         ("polygon", "mainnet-fork", "polygon.blockscout.com"),
+        ("polygon", "amoy", "polygon-amoy.blockscout.com"),
+        ("polygon", "amoy-fork", "polygon-amoy.blockscout.com"),
     ],
 )
 


### PR DESCRIPTION
### What I did

https://blog.ethereum.org/2023/11/30/goerli-lts-update
https://www.alchemy.com/blog/goerli-faucet-deprecation

Goerli support on all networks is ending soon:
- February 16th - [Base Goerli](https://www.alchemy.com/blog/base-goerli-testnet-deprecation)
- March 7th - [Optimism Goerli](https://www.alchemy.com/blog/optimism-goerli-testnet-deprecation)
- March 18th - [Arbitrum Goerli](https://www.alchemy.com/blog/arbitrum-goerli-testnet-deprecation)
- April 1st - [Ethereum Goerli](https://www.alchemy.com/blog/ethereum-goerli-testnet-deprecation)
- April 6th - [Polygon zkEVM Goerli](https://www.alchemy.com/blog/polygon-zkevm-cardona-is-live)
- April 11th - [Starknet Goerli](https://www.alchemy.com/blog/starknet-sepolia-is-live)
- April 13th - [Polygon Mumbai](https://www.alchemy.com/blog/polygon-mumbai-testnet-deprecation)


### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
